### PR TITLE
add package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,3 +51,6 @@ aiida.workflows=
     muon_app.implant_muon = aiidalab_qe_muon.workflows.implantmuonworkchain:ImplantMuonWorkChain
 console_scripts=
     install_muon_codes = aiidalab_qe_muon.scripts.post_install:InstallCodes
+
+[options.package_data]
+aiidalab_qe_muon.app.data = *


### PR DESCRIPTION
I install `aiidalab-qe-muon` using `pip`. I got this error when using the app.
```
No such file or directory: '/opt/conda/lib/python3.9/site-packages/aiidalab_qe_muon/app/data/isotopedata.txt'
```
This PR adds `package_data`, so that the files in the `data` folder will be packaged and uploaded to pypi.


@mikibonacci, you need to make a new release to Pypi after this PR.