### PR TITLE
Update Muon workflows for PythonJob 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "aiida-core>=2.8,<3",
     "aiida-muon @ git+https://github.com/mikibonacci/aiida-muon.git@main",
     "pymatgen>=2023.9.25",
-    "aiida-workgraph @ git+https://github.com/aiidateam/aiida-workgraph.git@a3c83ba88986",
+    "aiida-workgraph @ git+https://github.com/aiidateam/aiida-workgraph.git",
     "aiida-pythonjob==0.5.2",
     "undi @ git+https://github.com/mikibonacci/undi.git@update",
     "pybind11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "aiida-muon @ git+https://github.com/mikibonacci/aiida-muon.git@main",
     "pymatgen>=2023.9.25",
     "aiida-workgraph @ git+https://github.com/aiidateam/aiida-workgraph.git",
-    "aiida-pythonjob==0.5.2",
+    "aiida-pythonjob~=0.5.2",
     "undi @ git+https://github.com/mikibonacci/undi.git@update",
     "pybind11"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,13 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
 ]
 keywords = ["aiidalab", "plugin","muon"]
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 dependencies = [
+    "aiida-core>=2.8,<3",
     "aiida-muon @ git+https://github.com/mikibonacci/aiida-muon.git@main",
     "pymatgen>=2023.9.25",
-    "aiida-workgraph~=0.5.1",
-    "aiida-pythonjob~=0.2.5",
+    "aiida-workgraph @ git+https://github.com/aiidateam/aiida-workgraph.git@a3c83ba88986",
+    "aiida-pythonjob==0.5.2",
     "undi @ git+https://github.com/mikibonacci/undi.git@update",
     "pybind11"
 ]
@@ -40,7 +41,7 @@ pre-commit = [
 
 tests = [
     "pgtest~=1.3",
-    "pytest~=6.0",
+    "pytest>=8.0",
     "pytest-regressions~=2.3",
 ]
 

--- a/src/aiidalab_qe_muon/undi_interface/workflows/workgraphs.py
+++ b/src/aiidalab_qe_muon/undi_interface/workflows/workgraphs.py
@@ -1,53 +1,40 @@
 import typing as t
-from aiida_workgraph import task, WorkGraph, TaskPool
-#from aiidalab_qe_muon.undi_interface.calculations.pythonjobs import undi_run, compute_KT
 
-from aiida_workgraph import task
+from aiida_workgraph import spec, task
 
-@task.graph_builder(outputs=[{"name": "results", "from": "ctx.tmp_out"}])
+from aiidalab_qe_muon.undi_interface.calculations.pythonjobs import (
+    compute_KT,
+    undi_run,
+)
+
+
+def _metadata_with_label(metadata, label):
+    """Return task metadata with a stable call-link label."""
+    if hasattr(metadata, "get_dict"):
+        metadata = metadata.get_dict()
+    metadata = dict(metadata or {})
+    metadata["call_link_label"] = label
+    return metadata
+
+
+@task.graph
 def multiple_undi_analysis(
     structure,
-    B_mods: t.List[t.Union[float, int]] = [0.0], # Units are Tesla.
-    atom_as_muon: str = 'H',
+    B_mods: t.List[t.Union[float, int]] = [0.0],
+    atom_as_muon: str = "H",
     max_hdims: t.List[t.Union[float, int]] = [1e1],
     convergence_check: bool = False,
-    algorithm: str = 'fast',
+    algorithm: str = "fast",
     angular_integration_steps: int = 7,
-    code = None, # if None, default python3@localhost will be used.
-    metadata = {"options": {"custom_scheduler_commands": "export OMP_NUM_THREADS=1"}},
-):
-    
-    def undi_run(
-        structure, # should be StructureData, and then in the pythonjob we deserialize into ASE. for provenance.
-        B_mod = 0.0,
-        atom_as_muon = 'H',
-        max_hdim = 10e6,
-        convergence_check = False,
-        algorithm  = 'fast',
-        angular_integration_steps  = 7,
-        ) -> dict:
-        from undi.undi_analysis import execute_undi_analysis
-
-        results = execute_undi_analysis(
-            structure,
-            B_mod=B_mod,
-            atom_as_muon=atom_as_muon,
-            max_hdim=max_hdim,
-            convergence_check=convergence_check,
-            algorithm=algorithm,
-            angular_integration_steps=angular_integration_steps
-        )
-
-        return {"result": results}
-    
-    wg = WorkGraph()
-    
-    t = 0
+    code=None,
+    task_metadata={"options": {"custom_scheduler_commands": "export OMP_NUM_THREADS=1"}},
+) -> spec.namespace(results=spec.dynamic(t.Any)):
+    """Build parallel UNDI analyses for all fields and Hilbert-space sizes."""
+    results = {}
+    index = 0
     for B_mod in B_mods:
         for max_hdim in max_hdims:
-            tmp = wg.add_task(
-                TaskPool.workgraph.pythonjob,
-                function=undi_run,
+            output = undi_run(
                 structure=structure,
                 B_mod=B_mod,
                 max_hdim=max_hdim,
@@ -55,86 +42,46 @@ def multiple_undi_analysis(
                 convergence_check=convergence_check,
                 algorithm=algorithm,
                 angular_integration_steps=angular_integration_steps,
-                metadata=metadata,
-                name=f"iter_{t}",
-                deserializers={
-                    "aiida.orm.nodes.data.structure.StructureData": "aiida_pythonjob.data.deserializer.structure_data_to_atoms",
-                },
-                # override the default `AtomsData`
-                serializers={
-                    "ase.atoms.Atoms": "aiida_pythonjob.data.serializer.atoms_to_structure_data"
-                },
-                code = code,
+                metadata=_metadata_with_label(task_metadata, f"iter_{index}"),
+                code=code,
                 register_pickle_by_value=True,
             )
-            wg.update_ctx({f"tmp_out.iter_{t}": tmp.outputs.result})
-            t+=1
+            results[f"iter_{index}"] = output.results
+            index += 1
 
-    return wg
+    return {"results": results}
 
 
-@task.graph_builder(
-    outputs=[
-        {"name": "results", "from": "ctx.res"},
-        ]
-)
+@task.graph
 def UndiAndKuboToyabe(
     structure,
-    B_mods: t.List[t.Union[float, int]] = [0.0], # Units are Tesla.
-    atom_as_muon: str = 'H',
+    B_mods: t.List[t.Union[float, int]] = [0.0],
+    atom_as_muon: str = "H",
     max_hdims: t.List[t.Union[float, int]] = [1e1],
     convergence_check: bool = False,
-    algorithm: str = 'fast',
+    algorithm: str = "fast",
     angular_integration_steps: int = 7,
-    code=None, # if None, default python3@localhost will be used.
-    metadata = {"options": {"custom_scheduler_commands": "export OMP_NUM_THREADS=1"}},
-):
-    wg = WorkGraph()
-
-    # This conversion is done in the pythonjob de-serializat:qion
-    #if isinstance(structure, StructureData):
-    #    structure = structure.get_ase()
-    
-    def compute_KT(
-        structure,  # should be StructureData, and then in the pythonjob we deserialize into ASE. for provenance.
-        ):
-        import numpy as np
-        from undi.kubo_toyabe.KT import compute_second_moments, kubo_toyabe
-
-        t = np.linspace(0, 20e-6, 1000)  # time is seconds
-        sm = compute_second_moments(structure)
-        KT = kubo_toyabe(t, np.sum(list(sm.values())))
-
-        return {
-            "result": {
-                "t": (np.array(t)*1e6).tolist(), # this time is in microseconds
-                "KT": KT,
-            },
-        }
-
-    KT_task = wg.add_task(
-        TaskPool.workgraph.pythonjob,
-        function=compute_KT,
-        structure=structure,
-        name="KuboToyabe_run",
-        code = code,
-        metadata=metadata,
-        deserializers={
-            "aiida.orm.nodes.data.structure.StructureData": "aiida_pythonjob.data.deserializer.structure_data_to_atoms",
-        },
-        # override the default `AtomsData`
-        serializers={
-            "ase.atoms.Atoms": "aiida_pythonjob.data.serializer.atoms_to_structure_data"
-        },
-        register_pickle_by_value=True,
+    code=None,
+    task_metadata={"options": {"custom_scheduler_commands": "export OMP_NUM_THREADS=1"}},
+) -> spec.namespace(
+    results=spec.namespace(
+        KT_task=t.Any,
+        undi_conv_task=spec.dynamic(t.Any),
+        undi_task=spec.dynamic(t.Any),
     )
-    wg.update_ctx({f"res.KT_task": KT_task.outputs.result})
-    
-    # Convergence check
-    # in the future, we can add a logic to first converge, and then run UNDI for the B_mods list
+):
+    """Build the UNDI and Kubo-Toyabe polarization analyses."""
+    results = {
+        "KT_task": compute_KT(
+            structure=structure,
+            code=code,
+            metadata=_metadata_with_label(task_metadata, "KuboToyabe_run"),
+            register_pickle_by_value=True,
+        ).results
+    }
+
     if convergence_check:
-        undi_conv_task = wg.add_task(
-            multiple_undi_analysis,
+        results["undi_conv_task"] = multiple_undi_analysis(
             structure=structure,
             B_mods=[0.0],
             max_hdims=max_hdims,
@@ -142,14 +89,14 @@ def UndiAndKuboToyabe(
             convergence_check=convergence_check,
             algorithm=algorithm,
             angular_integration_steps=angular_integration_steps,
-            name="convergence_check",
-            code = code,
-            metadata=metadata,
-        )
-        wg.update_ctx({f"res.undi_conv_task": undi_conv_task.outputs.results})
+            code=code,
+            task_metadata=task_metadata,
+            metadata={"call_link_label": "convergence_check"},
+        ).results
+    else:
+        results["undi_conv_task"] = {}
 
-    undi_task = wg.add_task(
-        multiple_undi_analysis,
+    results["undi_task"] = multiple_undi_analysis(
         structure=structure,
         B_mods=B_mods,
         max_hdims=max_hdims[-2:-1],
@@ -157,37 +104,45 @@ def UndiAndKuboToyabe(
         convergence_check=False,
         algorithm=algorithm,
         angular_integration_steps=angular_integration_steps,
-        name="undi_runs",
-        code = code,
-        metadata=metadata,
-    )
-    wg.update_ctx({f"res.undi_task": undi_task.outputs.results})
+        code=code,
+        task_metadata=task_metadata,
+        metadata={"call_link_label": "undi_runs"},
+    ).results
 
-    return wg
+    return {"results": results}
 
-@task.graph_builder(outputs=[{"name": "results", "from": "ctx.res"}])
+
+@task.graph
 def MultiSites(
-    structure_group,
-    code=None, # if None, default python3@localhost will be used.
-    B_mods: t.List[t.Union[float, int]] = [0, 2e-3, 4e-3, 6e-3, 8e-3], # Units are Tesla.
-    max_hdims: t.List[t.Union[float, int]] = [10**2, 10**4, 10**6, 10**8], # we use the [-2:-1] for the undi run (not the convergence check, let's say).
-    metadata = {"options": {"custom_scheduler_commands": "export OMP_NUM_THREADS=1"}}, # just a default.
-    ):
-    
-    wg = WorkGraph("PolarizationMultiSites")
-    
-    for i, (idx, structure) in enumerate(structure_group.items()):
-        res = wg.add_task(
-            UndiAndKuboToyabe,
+    structure_group: t.Annotated[dict, spec.dynamic(t.Any)],
+    code=None,
+    B_mods: t.List[t.Union[float, int]] = [0, 2e-3, 4e-3, 6e-3, 8e-3],
+    max_hdims: t.List[t.Union[float, int]] = [10**2, 10**4, 10**6, 10**8],
+    task_metadata={"options": {"custom_scheduler_commands": "export OMP_NUM_THREADS=1"}},
+) -> spec.namespace(
+    results=spec.dynamic(
+        spec.namespace(
+            KT_task=t.Any,
+            undi_conv_task=spec.dynamic(t.Any),
+            undi_task=spec.dynamic(t.Any),
+        )
+    )
+):
+    """Build polarization analyses for all candidate muon sites."""
+    results = {}
+    for index, (site_index, structure) in enumerate(structure_group.items()):
+        output = UndiAndKuboToyabe(
             structure=structure,
             B_mods=B_mods,
             max_hdims=max_hdims,
-            convergence_check=i==0,  # maybe the convergence can be done for only one site, as done here now.
-            algorithm='fast',
-            name=f"polarization_structure_{idx}",
+            convergence_check=index == 0,
+            algorithm="fast",
             code=code,
-            metadata=metadata,
+            task_metadata=task_metadata,
+            metadata={
+                "call_link_label": f"polarization_structure_{site_index}"
+            },
         )
-        wg.update_ctx({f"res.site_{idx}": res.outputs.results})
-    
-    return wg
+        results[f"site_{site_index}"] = output.results
+
+    return {"results": results}

--- a/src/aiidalab_qe_muon/workflows/implantmuonworkchain.py
+++ b/src/aiidalab_qe_muon/workflows/implantmuonworkchain.py
@@ -404,11 +404,9 @@ class ImplantMuonWorkChain(WorkChain):
             B_mods = self.inputs.get("undi_fields", [0, 2e-3, 4e-3, 6e-3, 8e-3]),
             task_metadata = metadata,
             )
-        inputs = {
-            "workgraph_data": workgraph.to_dict(),
-            "metadata": {"call_link_label": "MultiSiteUndiPolarizationAndKT"},
-            
-        }
+        inputs = workgraph.to_engine_inputs(
+            metadata={"call_link_label": "MultiSiteUndiPolarizationAndKT"},
+        )
         process = self.submit(WorkGraphEngine, **inputs)
         self.report(
             f"submitting `Workgraph` for polarization calculation: <PK={process.pk}>"

--- a/src/aiidalab_qe_muon/workflows/implantmuonworkchain.py
+++ b/src/aiidalab_qe_muon/workflows/implantmuonworkchain.py
@@ -6,7 +6,6 @@ from aiida import orm
 from aiida.plugins import WorkflowFactory
 from aiida.engine import if_
 
-from aiida_workgraph import WorkGraph
 from aiida_workgraph.engine.workgraph import WorkGraphEngine
 from aiidalab_qe_muon.undi_interface.workflows.workgraphs import (
     MultiSites,
@@ -398,12 +397,12 @@ class ImplantMuonWorkChain(WorkChain):
         # need to parse all the output structures, and loop on them.
 
         metadata = self.inputs.get("undi_metadata", None)
-        workgraph = MultiSites(
+        workgraph = MultiSites.build(
             structure_group=self.ctx.structure_group,
             code = getattr(self.inputs, "undi_code", None),
             max_hdims = self.inputs.get("undi_max_hdims", [10**2, 10**4, 10**6, 10**8]),
             B_mods = self.inputs.get("undi_fields", [0, 2e-3, 4e-3, 6e-3, 8e-3]),
-            metadata = metadata,
+            task_metadata = metadata,
             )
         inputs = {
             "workgraph_data": workgraph.to_dict(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import tempfile
 import pytest
 from aiida import orm
 
-from aiidalab_qe.common.setup_pseudos import SSSP_VERSION
+from aiidalab_qe.setup.pseudos import SSSP_VERSION
 
 pytest_plugins = ["aiida.manage.tests.pytest_fixtures"]
 

--- a/tests/test_workgraphs.py
+++ b/tests/test_workgraphs.py
@@ -1,0 +1,44 @@
+from aiidalab_qe_muon.undi_interface.workflows.workgraphs import (
+    MultiSites,
+    UndiAndKuboToyabe,
+    multiple_undi_analysis,
+)
+
+
+def test_pythonjob_workgraph_builds():
+    structure = "structure"
+
+    leaf = multiple_undi_analysis.build(
+        structure=structure,
+        B_mods=[0.0],
+        max_hdims=[4],
+    )
+    assert [task.name for task in leaf.tasks if not task.name.startswith("graph_")] == [
+        "iter_0"
+    ]
+    assert leaf.outputs.results._get_keys() == ["iter_0"]
+
+    inner = UndiAndKuboToyabe.build(
+        structure=structure,
+        B_mods=[0.0],
+        max_hdims=[4, 4],
+        convergence_check=True,
+    )
+    assert [
+        task.name for task in inner.tasks if not task.name.startswith("graph_")
+    ] == ["KuboToyabe_run", "convergence_check", "undi_runs"]
+    assert inner.outputs.results._get_keys() == [
+        "KT_task",
+        "undi_conv_task",
+        "undi_task",
+    ]
+
+    outer = MultiSites.build(
+        structure_group={"0": structure},
+        B_mods=[0.0],
+        max_hdims=[4, 4],
+    )
+    assert [task.name for task in outer.tasks if not task.name.startswith("graph_")] == [
+        "polarization_structure_0"
+    ]
+    assert outer.outputs.results._get_keys() == ["site_0"]


### PR DESCRIPTION
@edan-bainglass @AndresOrtegaGuerrero

Updates the Muon polarization WorkGraphs for aiida-pythonjob 0.5.2 and the current WorkGraph API. It also sets Python >=3.12 and aiida-core >=2.8, refreshes the test dependency/import, and adds a focused graph-construction regression test.

The diff is larger than a dependency bump because current WorkGraph removed the legacy graph_builder and TaskPool.workgraph.pythonjob APIs. The three nested graph levels therefore need the new task.graph form and explicit output namespaces; the scientific routines and resulting output hierarchy are unchanged.

Depends on mikibonacci/undi#1 for the NumPy 2 metadata update. WorkGraph is pinned to upstream commit a3c83ba because the latest release still constrains aiida-core to 2.7, while current upstream supports aiida-core 2.8 and PythonJob 0.5.2.

Tested on the local AiiDAlab instance with Python 3.12.11, NumPy 2.5.1, aiidalab 26.5.2, aiidalab-qe 26.4.0, aiida-core 2.8.0, aiida-pythonjob 0.5.2, and aiida-workgraph a3c83ba. The Muon property loads, pip check passes, the focused regression test passes, and the full nested polarization WorkGraph finished successfully as PK 7773.

I am not familiar with this class of simulations, but tests before and after the PR for Si bulk seem to produce the same result
<img width="869" height="686" alt="image" src="https://github.com/user-attachments/assets/f2a184b6-9e12-4dd6-a5f7-afdaefc85b6b" />


Prepared with Codex.