### PR TITLE
Update `result` to `results` in output handling

### DIFF
--- a/src/aiidalab_qe_muon/app/results/sub_mvc/undimodel.py
+++ b/src/aiidalab_qe_muon/app/results/sub_mvc/undimodel.py
@@ -201,7 +201,7 @@ class PolarizationModel(Model):
                 )
 
                 results = [
-                    node.outputs.result.get_list() for node in descendants
+                    node.outputs.results.get_list() for node in descendants
                 ]
                 
                 fields = [
@@ -225,7 +225,7 @@ class PolarizationModel(Model):
                     self.muons[muon_index].KT_output = (
                         main_node.base.links.get_outgoing()
                         .get_node_by_label("KuboToyabe_run")
-                        .outputs.result.get_dict()
+                        .outputs.results.get_dict()
                     )
                 
                 # re-ordering all the results according to the fields or the max_hdim.

--- a/src/aiidalab_qe_muon/undi_interface/utils.py
+++ b/src/aiidalab_qe_muon/undi_interface/utils.py
@@ -33,7 +33,7 @@ def fetch_data(
             node.inputs.function_kwargs.max_hdim.value for node in descendants
         ]
         results = [
-            node.outputs.result.value["results"] for node in descendants
+            node.outputs.results.value["results"] for node in descendants
         ]
         isotopes = [
             [res["cluster_isotopes"], res["spins"], res["probability"]]
@@ -46,7 +46,7 @@ def fetch_data(
             KT_output = (
                 main_node.base.links.get_outgoing()
                 .get_node_by_label("KuboToyabe_run")
-                .outputs.result.get_dict()
+                .outputs.results.get_dict()
             )
         else:
             KT_output = None


### PR DESCRIPTION
Due to changes in `WorkGraph` API